### PR TITLE
Add simple examples for ADC and HardwareTimer

### DIFF
--- a/API.md
+++ b/API.md
@@ -104,6 +104,11 @@ using one of the below options:
  * [`build_opt.h`][build_opt.h]
  * header file of the variant: `variant_<boardname>.h`
 
+### ADC general
+ * setup: `pinMode(pin, INPUT_ANALOG);` 
+   has to be an ADC pin (e.g. PA0)
+ * read: `uint16_t adc_value = analogRead(pin);`
+
 ### ADC internal channels
 Available in core version greater than **1.5.0**
 

--- a/HardwareTimer-library.md
+++ b/HardwareTimer-library.md
@@ -286,6 +286,25 @@ Following examples are provided in [STM32Examples](https://github.com/stm32duino
         Callback toggles pin.
         Once configured, there is only CPU load for callbacks executions.
 
+   * Alternate timebase callback simple example
+     ```
+	 HardwareTimer timer1(TIM1);
+
+	 void timerCallback() {
+		// Toggle led pin. 
+		digitalWrite(LED_BUILTIN, ! digitalRead(LED_BUILTIN));
+	 }
+
+	 void setup()
+		pinMode(LED_BUILTIN, OUTPUT);
+		timer1.pause();
+		timer1.setOverflow(500000, MICROSEC_FORMAT); //set the period
+		timer1.attachInterrupt(timerCallback);
+		timer1.refresh();
+		timer1.resume();
+	 }
+	 ```
+
    * [Timebase_callback_with_parameter.ino](https://github.com/stm32duino/STM32Examples/blob/main/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback_with_parameter.ino)
 
         This example shows how to configure HardwareTimer to execute a callback with parameter at regular interval.

--- a/HardwareTimer-library.md
+++ b/HardwareTimer-library.md
@@ -288,21 +288,25 @@ Following examples are provided in [STM32Examples](https://github.com/stm32duino
 
    * Alternate timebase callback simple example
      ```
-	 HardwareTimer timer1(TIM1);
+HardwareTimer timer1(TIM1);
 
-	 void timerCallback() {
-		// Toggle led pin. 
-		digitalWrite(LED_BUILTIN, ! digitalRead(LED_BUILTIN));
-	 }
+void timerCallback() {
+  // Toggle led pin.
+  digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+}
 
-	 void setup()
-		pinMode(LED_BUILTIN, OUTPUT);
-		timer1.pause();
-		timer1.setOverflow(500000, MICROSEC_FORMAT); //set the period
-		timer1.attachInterrupt(timerCallback);
-		timer1.refresh();
-		timer1.resume();
-	 }
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+  timer1.pause();
+  timer1.setOverflow(500000, MICROSEC_FORMAT);  //set the period
+  timer1.attachInterrupt(timerCallback);
+  timer1.refresh();
+  timer1.resume();
+}
+
+void loop() {
+  // nothing to do
+}
 	 ```
 
    * [Timebase_callback_with_parameter.ino](https://github.com/stm32duino/STM32Examples/blob/main/examples/Peripherals/HardwareTimer/Timebase_callback_with_parameter/Timebase_callback_with_parameter.ino)


### PR DESCRIPTION
make it easier for new users reading the wiki to get started with the API for ADC (`analogRead()`) and `HardwareTimer`.

